### PR TITLE
fix(ops): two bugs uncovered during first production deploy

### DIFF
--- a/ops/compose/dagster.yaml
+++ b/ops/compose/dagster.yaml
@@ -61,3 +61,15 @@ retention:
     purge_after_days: 30
   sensor:
     purge_after_days: 30
+
+# Compute log capture: writes per-step stdout/stderr to disk for the UI.
+# Pinned to /tmp explicitly because the three Dagster containers run as
+# different users (dagster vs ql) with different DAGSTER_HOME values, and
+# Dagster's default path resolution can land on a directory that isn't
+# writable by the executing user. /tmp is writable by all users and the
+# logs are appropriately ephemeral.
+compute_logs:
+  module: dagster.core.storage.local_compute_log_manager
+  class: LocalComputeLogManager
+  config:
+    base_dir: /tmp/dagster-compute-logs

--- a/ops/compose/docker-compose.yml
+++ b/ops/compose/docker-compose.yml
@@ -20,7 +20,7 @@ name: quantumlane
 
 services:
   postgres:
-    image: postgis/postgis:16-3.4
+    image: imresamu/postgis:16-3.4
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-quantumlane}


### PR DESCRIPTION
## Context

First production deploy attempt (Hetzner Nuremberg CAX21, ARM) hit two failures that needed to be addressed before the system would run on anything other than the local x86 dev environment. Both issues are infrastructure-level rather than application logic, but they're real and would affect anyone trying to redeploy.

## Changes

**`ops/compose/docker-compose.yml`** — swapped `postgis/postgis:16-3.4` for `imresamu/postgis:16-3.4`.

The official `postgis/postgis` image publishes only `linux/amd64`. On ARM hosts (Hetzner CAX, Apple Silicon, ARM CI runners), Docker silently falls back to QEMU emulation. Postgres-on-emulation is too slow for docker-compose's default health check timeout, causing `make bootstrap` to hang at "Waiting for Postgres to be ready..." indefinitely.

`imresamu/postgis` is a community-maintained multi-arch alternative that mirrors the official image's tag conventions. On x86 the resulting binary is functionally identical; the change matters only when deploying to ARM. Keeping multi-arch even though the current production target is x86 (Hetzner Ashburn CPX21) preserves portability for future ARM deployments and dev environments.

**`ops/compose/dagster.yaml`** — added explicit `compute_logs` config pointing at `/tmp/dagster-compute-logs`.

`dagster-code` runs as the `ql` user with `DAGSTER_HOME=/home/ql/dagster`, while `dagster-webserver` and `dagster-daemon` run as the `dagster` user with `DAGSTER_HOME=/home/dagster`. Without an explicit compute_logs path, Dagster's default resolution can land on `/home/dagster` for steps executed by dagster-code, which `ql` can't write to. Result: `PermissionError: [Errno 13] Permission denied: '/home/dagster'` on every materialization.

`/tmp/dagster-compute-logs` is writable by all users in all containers. Compute logs are appropriately ephemeral; this is the simplest correct fix. A cleaner long-term solution (aligning user IDs across Dagster containers, or using `CloudComputeLogManager` to ship logs to R2) is tracked separately.

## Verification

- Local stack on x86 dev (Jarvis): `make down && make up` succeeds, all three Dagster services come up clean, freshness page goes green within 90 seconds.
- Production stack on Hetzner Ashburn CPX21 (x86): same — TTC ingestion jobs running successfully, no permission errors in logs.

## Known follow-ups

- ADR-004 ("Hetzner over AWS") needs updating to document deployment-region constraints surfaced by these issues. Tracked in BACKLOG.
- The `imresamu/postgis` dependency is community-maintained; revisit if release cadence falls behind official `postgis/postgis`. Tracked in BACKLOG.
- Cleaner long-term fix for cross-container user ID alignment in Dagster. Tracked in BACKLOG.